### PR TITLE
Export/Env fix

### DIFF
--- a/src/built-ins/env.c
+++ b/src/built-ins/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mira <mira@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: mortins- <mortins-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/07 17:08:15 by mira              #+#    #+#             */
-/*   Updated: 2023/08/02 14:30:35 by mira             ###   ########.fr       */
+/*   Updated: 2023/10/26 16:51:44 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ t_list	**env_init(char **envp)
 void	env_override(char *str, t_list **env)
 {
 	t_list	*tmp;
+	t_list	*node;
 
 	tmp = *env;
 	while (tmp)
@@ -49,5 +50,10 @@ void	env_override(char *str, t_list **env)
 			break ;
 		}
 		tmp = tmp->next;
+	}
+	if (!tmp && ft_strchr(str, '='))
+	{
+		node = ft_lstnew(ft_strdup(str));
+		ft_lstadd_back(env, node);
 	}
 }

--- a/src/built-ins/export.c
+++ b/src/built-ins/export.c
@@ -6,7 +6,7 @@
 /*   By: mortins- <mortins-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 16:31:09 by ddiniz-m          #+#    #+#             */
-/*   Updated: 2023/10/26 16:27:53 by mortins-         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:36:28 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,10 +109,10 @@ int	export_override(char *str, t_list **export)
 	buf = export_str(str);
 	while (tmp)
 	{
-		if (!ft_strchr(buf, '=') && ft_strcmp(tmp->data, buf) == 0)
+		if (!ft_strchr(buf, '=') && strcmp_nochr(buf, tmp->data, '=') == 0)
 			break ;
-		if (strcmp_chr((char *)tmp->data, buf, '=') == 0
-			|| ft_strcmp((char *)tmp->data, buf) == 0)
+		if (strcmp_chr(tmp->data, buf, '=') == 0 || (!ft_strchr(tmp->data, '=') \
+			&& strcmp_nochr(tmp->data, buf, '=') == 0))
 		{
 			free(tmp->data);
 			tmp->data = ft_strdup(buf);

--- a/src/built-ins/export.c
+++ b/src/built-ins/export.c
@@ -6,7 +6,7 @@
 /*   By: mortins- <mortins-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 16:31:09 by ddiniz-m          #+#    #+#             */
-/*   Updated: 2023/10/26 16:36:28 by mortins-         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:51:36 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,12 +141,6 @@ void	export(char **arr, t_list **export, t_list **env)
 		{
 			i++;
 			continue ;
-		}
-		if (ft_strchr(arr[i], '='))
-		{
-			buf = ft_strdup(arr[i]);
-			node = ft_lstnew(buf);
-			ft_lstadd_back(env, node);
 		}
 		node = ft_lstnew(export_str(arr[i]));
 		ft_lstadd_back(export, node);

--- a/src/built-ins/export.c
+++ b/src/built-ins/export.c
@@ -6,7 +6,7 @@
 /*   By: mortins- <mortins-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 16:31:09 by ddiniz-m          #+#    #+#             */
-/*   Updated: 2023/10/19 16:50:24 by mortins-         ###   ########.fr       */
+/*   Updated: 2023/10/26 16:27:53 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,7 +109,7 @@ int	export_override(char *str, t_list **export)
 	buf = export_str(str);
 	while (tmp)
 	{
-		if (!ft_strchr(buf, '='))
+		if (!ft_strchr(buf, '=') && ft_strcmp(tmp->data, buf) == 0)
 			break ;
 		if (strcmp_chr((char *)tmp->data, buf, '=') == 0
 			|| ft_strcmp((char *)tmp->data, buf) == 0)
@@ -136,19 +136,20 @@ void	export(char **arr, t_list **export, t_list **env)
 	buf = NULL;
 	while (i < arr_size(arr))
 	{
-		buf = ft_strdup(arr[i++]);
-		env_override(buf, env);
-		if (export_override(buf, export))
+		env_override(arr[i], env);
+		if (export_override(arr[i], export) == 1)
 		{
-			free(buf);
+			i++;
 			continue ;
 		}
-		if (ft_strchr(buf, '='))
+		if (ft_strchr(arr[i], '='))
 		{
+			buf = ft_strdup(arr[i]);
 			node = ft_lstnew(buf);
 			ft_lstadd_back(env, node);
 		}
-		node = ft_lstnew(export_str(buf));
+		node = ft_lstnew(export_str(arr[i]));
 		ft_lstadd_back(export, node);
+		i++;
 	}
 }


### PR DESCRIPTION
What I fixed:
- `export VAR` wouldn't create a new variable `VAR` with no value if a `VAR` variable didn't already exist.
- After fixing the previous error, if a variable was originally created with no value using `export VAR`, when the user tried to overwrite it using for example:  `export VAR=123`, the variable would not be added to `env`.