### PR TITLE
fixed echo flag interpretation

### DIFF
--- a/src/built-ins/echo.c
+++ b/src/built-ins/echo.c
@@ -20,13 +20,13 @@ int	echo_flag(char *str)
 
 	i = 0;
 	if (str[i] != '-')
-		return (1);
+		return (0);
 	i++;
 	while (str[i] && str[i] == 'n')
 		i++;
 	if (str[i])
-		return (1);
-	return (0);
+		return (0);
+	return (1);
 }
 
 void	echo_print(char **cmd_args, int pos)
@@ -65,7 +65,7 @@ int	ft_echo(t_minishell *ms, char **cmd_args)
 	n_flag = 0;
 	ms->exit = 0;
 	cmds = arr_size(cmd_args);
-	while (cmd_args[j] && ft_strcmp(cmd_args[j], "-n") == 0)
+	while (cmd_args[j] && echo_flag(cmd_args[j]))
 	{
 		n_flag = 1;
 		j++;


### PR DESCRIPTION
Fixed minishell not interpreting `echo -nnnn a` correctly